### PR TITLE
Support Xcode 7 with Swift 2

### DIFF
--- a/MyPlayground.playground/contents.xcplayground
+++ b/MyPlayground.playground/contents.xcplayground
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<playground version='3.0' sdk='iphonesimulator'>
+<playground version='3.0' sdk='iphonesimulator' runInFullSimulator='YES'>
     <sections>
         <code source-file-name='section-1.swift'/>
     </sections>

--- a/MyPlayground.playground/section-1.swift
+++ b/MyPlayground.playground/section-1.swift
@@ -8,9 +8,9 @@ UTI(MIMEType: "image/jpeg").filenameExtensions
 
 UTI(filenameExtension: "jpeg") == UTI(MIMEType: "image/jpeg")
 
-switch UTI(kUTTypeJPEG) {
-case UTI(kUTTypeImage):
-    println("JPEG is a kind of images")
+switch UTI(kUTTypeJPEG as String) {
+case UTI(kUTTypeImage as String):
+    print("JPEG is a kind of images")
 default:
     fatalError("JPEG must be a image")
 }

--- a/MyPlayground.playground/timeline.xctimeline
+++ b/MyPlayground.playground/timeline.xctimeline
@@ -3,10 +3,14 @@
    version = "3.0">
    <TimelineItems>
       <LoggerValueHistoryTimelineItem
-         documentLocation = "#CharacterRangeLen=0&amp;CharacterRangeLoc=172&amp;EndingColumnNumber=60&amp;EndingLineNumber=16&amp;StartingColumnNumber=35&amp;StartingLineNumber=15&amp;Timestamp=446226906.793095">
+         documentLocation = "#CharacterRangeLen=0&amp;CharacterRangeLoc=172&amp;EndingColumnNumber=60&amp;EndingLineNumber=15&amp;StartingColumnNumber=35&amp;StartingLineNumber=15&amp;Timestamp=456154386.377106"
+         selectedRepresentationIndex = "0"
+         shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>
       <LoggerValueHistoryTimelineItem
-         documentLocation = "#CharacterRangeLen=0&amp;CharacterRangeLoc=312&amp;EndingColumnNumber=32&amp;EndingLineNumber=16&amp;StartingColumnNumber=1&amp;StartingLineNumber=15&amp;Timestamp=446226906.793388">
+         documentLocation = "#CharacterRangeLen=0&amp;CharacterRangeLoc=312&amp;EndingColumnNumber=32&amp;EndingLineNumber=15&amp;StartingColumnNumber=1&amp;StartingLineNumber=15&amp;Timestamp=456154386.377263"
+         selectedRepresentationIndex = "0"
+         shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>
    </TimelineItems>
 </Timeline>

--- a/UTIKit.xcodeproj/project.pbxproj
+++ b/UTIKit.xcodeproj/project.pbxproj
@@ -465,10 +465,6 @@
 		09FD21551A962FC00071BF6B /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
-				FRAMEWORK_SEARCH_PATHS = (
-					"$(SDKROOT)/Developer/Library/Frameworks",
-					"$(inherited)",
-				);
 				GCC_PREPROCESSOR_DEFINITIONS = (
 					"DEBUG=1",
 					"$(inherited)",
@@ -483,10 +479,6 @@
 		09FD21561A962FC00071BF6B /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
-				FRAMEWORK_SEARCH_PATHS = (
-					"$(SDKROOT)/Developer/Library/Frameworks",
-					"$(inherited)",
-				);
 				INFOPLIST_FILE = UTIKitTests/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = "info.cockscomb.$(PRODUCT_NAME:rfc1034identifier)";

--- a/UTIKit.xcodeproj/project.pbxproj
+++ b/UTIKit.xcodeproj/project.pbxproj
@@ -200,7 +200,8 @@
 		09FD21321A962FC00071BF6B /* Project object */ = {
 			isa = PBXProject;
 			attributes = {
-				LastUpgradeCheck = 0610;
+				LastSwiftUpdateCheck = 0700;
+				LastUpgradeCheck = 0700;
 				ORGANIZATIONNAME = cockscomb.info;
 				TargetAttributes = {
 					09F886601A98D47E00ADF55F = {
@@ -310,6 +311,7 @@
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks @loader_path/Frameworks";
 				MACOSX_DEPLOYMENT_TARGET = 10.10;
+				PRODUCT_BUNDLE_IDENTIFIER = "info.cockscomb.$(PRODUCT_NAME:rfc1034identifier)";
 				PRODUCT_NAME = UTIKit;
 				SDKROOT = macosx;
 				SKIP_INSTALL = YES;
@@ -330,6 +332,7 @@
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks @loader_path/Frameworks";
 				MACOSX_DEPLOYMENT_TARGET = 10.10;
+				PRODUCT_BUNDLE_IDENTIFIER = "info.cockscomb.$(PRODUCT_NAME:rfc1034identifier)";
 				PRODUCT_NAME = UTIKit;
 				SDKROOT = macosx;
 				SKIP_INSTALL = YES;
@@ -357,6 +360,7 @@
 				COPY_PHASE_STRIP = NO;
 				CURRENT_PROJECT_VERSION = 1;
 				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				ENABLE_TESTABILITY = YES;
 				GCC_C_LANGUAGE_STANDARD = gnu99;
 				GCC_DYNAMIC_NO_PIC = NO;
 				GCC_OPTIMIZATION_LEVEL = 0;
@@ -433,6 +437,7 @@
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				PRODUCT_BUNDLE_IDENTIFIER = "info.cockscomb.$(PRODUCT_NAME:rfc1034identifier)";
 				PRODUCT_NAME = UTIKit;
 				SKIP_INSTALL = YES;
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
@@ -451,6 +456,7 @@
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				PRODUCT_BUNDLE_IDENTIFIER = "info.cockscomb.$(PRODUCT_NAME:rfc1034identifier)";
 				PRODUCT_NAME = UTIKit;
 				SKIP_INSTALL = YES;
 			};
@@ -469,6 +475,7 @@
 				);
 				INFOPLIST_FILE = UTIKitTests/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				PRODUCT_BUNDLE_IDENTIFIER = "info.cockscomb.$(PRODUCT_NAME:rfc1034identifier)";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 			};
 			name = Debug;
@@ -482,6 +489,7 @@
 				);
 				INFOPLIST_FILE = UTIKitTests/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				PRODUCT_BUNDLE_IDENTIFIER = "info.cockscomb.$(PRODUCT_NAME:rfc1034identifier)";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 			};
 			name = Release;

--- a/UTIKit.xcodeproj/xcshareddata/xcschemes/UTIKit OS X.xcscheme
+++ b/UTIKit.xcodeproj/xcshareddata/xcschemes/UTIKit OS X.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "0610"
+   LastUpgradeVersion = "0700"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/UTIKit.xcodeproj/xcshareddata/xcschemes/UTIKit OS X.xcscheme
+++ b/UTIKit.xcodeproj/xcshareddata/xcschemes/UTIKit OS X.xcscheme
@@ -62,6 +62,8 @@
             ReferencedContainer = "container:UTIKit.xcodeproj">
          </BuildableReference>
       </MacroExpansion>
+      <AdditionalOptions>
+      </AdditionalOptions>
    </TestAction>
    <LaunchAction
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
@@ -71,6 +73,7 @@
       buildConfiguration = "Debug"
       ignoresPersistentStateOnLaunch = "NO"
       debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
       allowLocationSimulation = "YES">
       <MacroExpansion>
          <BuildableReference

--- a/UTIKit.xcodeproj/xcshareddata/xcschemes/UTIKit iOS.xcscheme
+++ b/UTIKit.xcodeproj/xcshareddata/xcschemes/UTIKit iOS.xcscheme
@@ -37,10 +37,11 @@
       </BuildActionEntries>
    </BuildAction>
    <TestAction
+      buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
       shouldUseLaunchSchemeArgsEnv = "YES"
-      buildConfiguration = "Debug">
+      codeCoverageEnabled = "YES">
       <Testables>
          <TestableReference
             skipped = "NO">
@@ -66,11 +67,11 @@
       </AdditionalOptions>
    </TestAction>
    <LaunchAction
+      buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
       launchStyle = "0"
       useCustomWorkingDirectory = "NO"
-      buildConfiguration = "Debug"
       ignoresPersistentStateOnLaunch = "NO"
       debugDocumentVersioning = "YES"
       debugServiceExtension = "internal"
@@ -88,10 +89,10 @@
       </AdditionalOptions>
    </LaunchAction>
    <ProfileAction
+      buildConfiguration = "Release"
       shouldUseLaunchSchemeArgsEnv = "YES"
       savedToolIdentifier = ""
       useCustomWorkingDirectory = "NO"
-      buildConfiguration = "Release"
       debugDocumentVersioning = "YES">
       <MacroExpansion>
          <BuildableReference

--- a/UTIKit.xcodeproj/xcshareddata/xcschemes/UTIKit iOS.xcscheme
+++ b/UTIKit.xcodeproj/xcshareddata/xcschemes/UTIKit iOS.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "0610"
+   LastUpgradeVersion = "0700"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"
@@ -62,6 +62,8 @@
             ReferencedContainer = "container:UTIKit.xcodeproj">
          </BuildableReference>
       </MacroExpansion>
+      <AdditionalOptions>
+      </AdditionalOptions>
    </TestAction>
    <LaunchAction
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
@@ -71,6 +73,7 @@
       buildConfiguration = "Debug"
       ignoresPersistentStateOnLaunch = "NO"
       debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
       allowLocationSimulation = "YES">
       <MacroExpansion>
          <BuildableReference

--- a/UTIKit/Info.plist
+++ b/UTIKit/Info.plist
@@ -7,7 +7,7 @@
 	<key>CFBundleExecutable</key>
 	<string>$(EXECUTABLE_NAME)</string>
 	<key>CFBundleIdentifier</key>
-	<string>info.cockscomb.$(PRODUCT_NAME:rfc1034identifier)</string>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
 	<key>CFBundleInfoDictionaryVersion</key>
 	<string>6.0</string>
 	<key>CFBundleName</key>

--- a/UTIKit/UTI.swift
+++ b/UTIKit/UTI.swift
@@ -26,7 +26,7 @@ import Foundation
 import MobileCoreServices
 #endif
 
-public struct UTI: Printable, DebugPrintable, Equatable {
+public struct UTI: CustomStringConvertible, CustomDebugStringConvertible, Equatable {
 
     public let UTIString: String
 
@@ -38,23 +38,23 @@ public struct UTI: Printable, DebugPrintable, Equatable {
 
     public init(filenameExtension: String, conformingToUTI: UTI? = nil) {
         let conformingToUTIString: CFString? = conformingToUTI?.UTIString
-        self.UTIString = UTTypeCreatePreferredIdentifierForTag(kUTTagClassFilenameExtension, filenameExtension, conformingToUTIString).takeRetainedValue() as String
+        self.UTIString = UTTypeCreatePreferredIdentifierForTag(kUTTagClassFilenameExtension, filenameExtension, conformingToUTIString)!.takeRetainedValue() as String
     }
 
     public init(MIMEType: String, conformingToUTI: UTI? = nil) {
         let conformingToUTIString: CFString? = conformingToUTI?.UTIString
-        self.UTIString = UTTypeCreatePreferredIdentifierForTag(kUTTagClassMIMEType, MIMEType, conformingToUTIString).takeRetainedValue() as String
+        self.UTIString = UTTypeCreatePreferredIdentifierForTag(kUTTagClassMIMEType, MIMEType, conformingToUTIString)!.takeRetainedValue() as String
     }
 
     #if os(OSX)
     public init(pasteBoardType: String, conformingToUTI: UTI? = nil) {
         let conformingToUTIString: CFString? = conformingToUTI?.UTIString
-        self.UTIString = UTTypeCreatePreferredIdentifierForTag(kUTTagClassNSPboardType, pasteBoardType, conformingToUTIString).takeRetainedValue() as String
+        self.UTIString = UTTypeCreatePreferredIdentifierForTag(kUTTagClassNSPboardType, pasteBoardType, conformingToUTIString)!.takeRetainedValue() as String
     }
 
     public init(OSType: String, conformingToUTI: UTI? = nil) {
         let conformingToUTIString: CFString? = conformingToUTI?.UTIString
-        self.UTIString = UTTypeCreatePreferredIdentifierForTag(kUTTagClassOSType, OSType, conformingToUTIString).takeRetainedValue() as String
+        self.UTIString = UTTypeCreatePreferredIdentifierForTag(kUTTagClassOSType, OSType, conformingToUTIString)!.takeRetainedValue() as String
     }
     #endif
 
@@ -62,7 +62,7 @@ public struct UTI: Printable, DebugPrintable, Equatable {
 
     private static func UTIsForTagClass(tagClass: String, tag: String, conformingToUTI: UTI?) -> [UTI] {
         let conformingToUTIString: CFString? = conformingToUTI?.UTIString
-        return (UTTypeCreateAllIdentifiersForTag(tagClass, tag, conformingToUTIString).takeRetainedValue() as! [String]).map { UTI($0) }
+        return (UTTypeCreateAllIdentifiersForTag(tagClass, tag, conformingToUTIString)!.takeRetainedValue() as NSArray as! [String]).map { UTI($0) }
     }
 
     public static func UTIsFromFilenameExtension(filenameExtension: String, conformingToUTI: UTI? = nil) -> [UTI] {
@@ -89,18 +89,18 @@ public struct UTI: Printable, DebugPrintable, Equatable {
         return UTTypeCopyPreferredTagWithClass(UTIString, tagClass)?.takeRetainedValue() as String?
     }
 
-    @availability(OSX, introduced=10.10)
-    @availability(iOS, introduced=8.0)
+    @available(OSX, introduced=10.10)
+    @available(iOS, introduced=8.0)
     private func tagsWithClass(tagClass: String) -> [String] {
-        return UTTypeCopyAllTagsWithClass(UTIString, tagClass)?.takeRetainedValue() as? [String] ?? []
+        return UTTypeCopyAllTagsWithClass(UTIString, tagClass).flatMap{$0.takeRetainedValue() as NSArray as? [String]} ?? []
     }
 
     public var filenameExtension: String? {
         return tagWithClass(kUTTagClassFilenameExtension as String)
     }
 
-    @availability(OSX, introduced=10.10)
-    @availability(iOS, introduced=8.0)
+    @available(OSX, introduced=10.10)
+    @available(iOS, introduced=8.0)
     public var filenameExtensions: [String] {
         return tagsWithClass(kUTTagClassFilenameExtension as String)
     }
@@ -109,8 +109,8 @@ public struct UTI: Printable, DebugPrintable, Equatable {
         return tagWithClass(kUTTagClassMIMEType as String)
     }
 
-    @availability(OSX, introduced=10.10)
-    @availability(iOS, introduced=8.0)
+    @available(OSX, introduced=10.10)
+    @available(iOS, introduced=8.0)
     public var MIMETypes: [String] {
         return tagsWithClass(kUTTagClassMIMEType as String)
     }
@@ -120,7 +120,7 @@ public struct UTI: Printable, DebugPrintable, Equatable {
         return tagWithClass(kUTTagClassNSPboardType as String)
     }
 
-    @availability(OSX, introduced=10.10)
+    @available(OSX, introduced=10.10)
     public var pasteBoardTypes: [String] {
         return tagsWithClass(kUTTagClassNSPboardType as String)
     }
@@ -129,7 +129,7 @@ public struct UTI: Printable, DebugPrintable, Equatable {
         return tagWithClass(kUTTagClassOSType as String)
     }
 
-    @availability(OSX, introduced=10.10)
+    @available(OSX, introduced=10.10)
     public var OSTypes: [String] {
         return tagsWithClass(kUTTagClassOSType as String)
     }
@@ -137,21 +137,21 @@ public struct UTI: Printable, DebugPrintable, Equatable {
 
     // MARK: - Status
 
-    @availability(OSX, introduced=10.10)
-    @availability(iOS, introduced=8.0)
+    @available(OSX, introduced=10.10)
+    @available(iOS, introduced=8.0)
     public var isDeclared: Bool {
         return UTTypeIsDeclared(UTIString) == 1
     }
 
-    @availability(OSX, introduced=10.10)
-    @availability(iOS, introduced=8.0)
+    @available(OSX, introduced=10.10)
+    @available(iOS, introduced=8.0)
     public var isDynamic: Bool {
         return UTTypeIsDynamic(UTIString) == 1
     }
 
     // MARK: - Declaration
 
-    public struct Declaration: Printable, DebugPrintable {
+    public struct Declaration: CustomStringConvertible, CustomDebugStringConvertible {
         private let raw: [ NSObject: AnyObject ]
 
         public var exportedTypeDeclarations: [Declaration] {
@@ -201,17 +201,17 @@ public struct UTI: Printable, DebugPrintable, Equatable {
         }
 
         public var description: String {
-            return toString(raw)
+            return String(raw)
         }
 
         public var debugDescription: String {
-            return toDebugString(raw)
+            return String(reflecting: raw)
         }
 
     }
 
     public var declaration: Declaration {
-        return Declaration(declaration: UTTypeCopyDeclaration(self.UTIString)?.takeRetainedValue() as? [NSObject: AnyObject] ?? [:])
+        return Declaration(declaration: UTTypeCopyDeclaration(self.UTIString)?.takeRetainedValue() as [NSObject: AnyObject]? ?? [:])
     }
 
     public var declaringBundle: NSBundle? {
@@ -229,7 +229,7 @@ public struct UTI: Printable, DebugPrintable, Equatable {
         return nil
     }
 
-    // MARK: - Printable, DebugPrintable
+    // MARK: - CustomStringConvertible, CustomDebugStringConvertible
 
     public var description: String {
         return UTTypeCopyDescription(UTIString)?.takeRetainedValue() as? String ?? UTIString

--- a/UTIKit/UTI.swift
+++ b/UTIKit/UTI.swift
@@ -140,13 +140,13 @@ public struct UTI: CustomStringConvertible, CustomDebugStringConvertible, Equata
     @available(OSX, introduced=10.10)
     @available(iOS, introduced=8.0)
     public var isDeclared: Bool {
-        return UTTypeIsDeclared(UTIString) == 1
+        return UTTypeIsDeclared(UTIString)
     }
 
     @available(OSX, introduced=10.10)
     @available(iOS, introduced=8.0)
     public var isDynamic: Bool {
-        return UTTypeIsDynamic(UTIString) == 1
+        return UTTypeIsDynamic(UTIString)
     }
 
     // MARK: - Declaration
@@ -242,9 +242,9 @@ public struct UTI: CustomStringConvertible, CustomDebugStringConvertible, Equata
 }
 
 public func ==(lhs: UTI, rhs: UTI) -> Bool {
-    return UTTypeEqual(lhs.UTIString, rhs.UTIString) == 1
+    return UTTypeEqual(lhs.UTIString, rhs.UTIString)
 }
 
 public func ~=(pattern: UTI, value: UTI) -> Bool {
-    return UTTypeConformsTo(value.UTIString, pattern.UTIString) == 1
+    return UTTypeConformsTo(value.UTIString, pattern.UTIString)
 }

--- a/UTIKitTests/Info.plist
+++ b/UTIKitTests/Info.plist
@@ -7,7 +7,7 @@
 	<key>CFBundleExecutable</key>
 	<string>$(EXECUTABLE_NAME)</string>
 	<key>CFBundleIdentifier</key>
-	<string>info.cockscomb.$(PRODUCT_NAME:rfc1034identifier)</string>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
 	<key>CFBundleInfoDictionaryVersion</key>
 	<string>6.0</string>
 	<key>CFBundleName</key>


### PR DESCRIPTION
I have converted to Swift 2, with some points:
- As documented, `UTTypeCreatePreferredIdentifierForTag` now return NULL if `inTagClass` is not a known tag class. With known constants for `inTagClass`, I think we can use forced unwrapping.
- downcasting directly `CFArray as? [String]` now always fail. As a workaround, I added preceding `as NSArray` casts.
