### PR TITLE
Swift3.0

### DIFF
--- a/UTIKit.xcodeproj/project.pbxproj
+++ b/UTIKit.xcodeproj/project.pbxproj
@@ -202,7 +202,7 @@
 			attributes = {
 				LastSwiftMigration = 0700;
 				LastSwiftUpdateCheck = 0700;
-				LastUpgradeCheck = 0700;
+				LastUpgradeCheck = 0800;
 				ORGANIZATIONNAME = cockscomb.info;
 				TargetAttributes = {
 					09F886601A98D47E00ADF55F = {
@@ -341,6 +341,7 @@
 				PRODUCT_NAME = UTIKit;
 				SDKROOT = macosx;
 				SKIP_INSTALL = YES;
+				SWIFT_OPTIMIZATION_LEVEL = "-Owholemodule";
 			};
 			name = Release;
 		};
@@ -368,6 +369,7 @@
 				ENABLE_TESTABILITY = YES;
 				GCC_C_LANGUAGE_STANDARD = gnu99;
 				GCC_DYNAMIC_NO_PIC = NO;
+				GCC_NO_COMMON_BLOCKS = YES;
 				GCC_OPTIMIZATION_LEVEL = 0;
 				GCC_PREPROCESSOR_DEFINITIONS = (
 					"DEBUG=1",
@@ -414,6 +416,7 @@
 				ENABLE_NS_ASSERTIONS = NO;
 				ENABLE_STRICT_OBJC_MSGSEND = YES;
 				GCC_C_LANGUAGE_STANDARD = gnu99;
+				GCC_NO_COMMON_BLOCKS = YES;
 				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
 				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
 				GCC_WARN_UNDECLARED_SELECTOR = YES;
@@ -447,7 +450,7 @@
 				PRODUCT_NAME = UTIKit;
 				SKIP_INSTALL = YES;
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
-				SWIFT_VERSION = 2.3;
+				SWIFT_VERSION = 3.0;
 			};
 			name = Debug;
 		};
@@ -467,7 +470,8 @@
 				PRODUCT_BUNDLE_IDENTIFIER = "info.cockscomb.$(PRODUCT_NAME:rfc1034identifier)";
 				PRODUCT_NAME = UTIKit;
 				SKIP_INSTALL = YES;
-				SWIFT_VERSION = 2.3;
+				SWIFT_OPTIMIZATION_LEVEL = "-Owholemodule";
+				SWIFT_VERSION = 3.0;
 			};
 			name = Release;
 		};
@@ -486,7 +490,7 @@
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = "info.cockscomb.$(PRODUCT_NAME:rfc1034identifier)";
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				SWIFT_VERSION = 2.3;
+				SWIFT_VERSION = 3.0;
 			};
 			name = Debug;
 		};
@@ -501,7 +505,8 @@
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = "info.cockscomb.$(PRODUCT_NAME:rfc1034identifier)";
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				SWIFT_VERSION = 2.3;
+				SWIFT_OPTIMIZATION_LEVEL = "-Owholemodule";
+				SWIFT_VERSION = 3.0;
 			};
 			name = Release;
 		};

--- a/UTIKit.xcodeproj/project.pbxproj
+++ b/UTIKit.xcodeproj/project.pbxproj
@@ -210,9 +210,11 @@
 					};
 					09FD213A1A962FC00071BF6B = {
 						CreatedOnToolsVersion = 6.1.1;
+						LastSwiftMigration = 0800;
 					};
 					09FD21451A962FC00071BF6B = {
 						CreatedOnToolsVersion = 6.1.1;
+						LastSwiftMigration = 0800;
 					};
 				};
 			};
@@ -445,6 +447,7 @@
 				PRODUCT_NAME = UTIKit;
 				SKIP_INSTALL = YES;
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+				SWIFT_VERSION = 2.3;
 			};
 			name = Debug;
 		};
@@ -464,6 +467,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = "info.cockscomb.$(PRODUCT_NAME:rfc1034identifier)";
 				PRODUCT_NAME = UTIKit;
 				SKIP_INSTALL = YES;
+				SWIFT_VERSION = 2.3;
 			};
 			name = Release;
 		};
@@ -482,6 +486,7 @@
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = "info.cockscomb.$(PRODUCT_NAME:rfc1034identifier)";
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_VERSION = 2.3;
 			};
 			name = Debug;
 		};
@@ -496,6 +501,7 @@
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = "info.cockscomb.$(PRODUCT_NAME:rfc1034identifier)";
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_VERSION = 2.3;
 			};
 			name = Release;
 		};

--- a/UTIKit.xcodeproj/project.pbxproj
+++ b/UTIKit.xcodeproj/project.pbxproj
@@ -478,10 +478,6 @@
 		09FD21551A962FC00071BF6B /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
-				FRAMEWORK_SEARCH_PATHS = (
-					"$(SDKROOT)/Developer/Library/Frameworks",
-					"$(inherited)",
-				);
 				GCC_PREPROCESSOR_DEFINITIONS = (
 					"DEBUG=1",
 					"$(inherited)",
@@ -497,10 +493,6 @@
 		09FD21561A962FC00071BF6B /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
-				FRAMEWORK_SEARCH_PATHS = (
-					"$(SDKROOT)/Developer/Library/Frameworks",
-					"$(inherited)",
-				);
 				INFOPLIST_FILE = UTIKitTests/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = "info.cockscomb.$(PRODUCT_NAME:rfc1034identifier)";

--- a/UTIKit.xcodeproj/xcshareddata/xcschemes/UTIKit OS X.xcscheme
+++ b/UTIKit.xcodeproj/xcshareddata/xcschemes/UTIKit OS X.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "0700"
+   LastUpgradeVersion = "0800"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/UTIKit.xcodeproj/xcshareddata/xcschemes/UTIKit iOS.xcscheme
+++ b/UTIKit.xcodeproj/xcshareddata/xcschemes/UTIKit iOS.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "0700"
+   LastUpgradeVersion = "0800"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/UTIKit/UTI.swift
+++ b/UTIKit/UTI.swift
@@ -64,17 +64,17 @@ public struct UTI: CustomStringConvertible, CustomDebugStringConvertible, Equata
 
     // MARK: -
 
-    private static func UTIsForTagClass(tagClass: String, tag: String, conformingToUTI: UTI?) -> [UTI] {
+    private static func UTIsForTagClass(_ tagClass: String, tag: String, conformingToUTI: UTI?) -> [UTI] {
         let conformingToUTIString: CFString? = conformingToUTI?.UTIString
         guard let rawUTIs = UTTypeCreateAllIdentifiersForTag(tagClass, tag, conformingToUTIString)?.takeRetainedValue() else { return [] }
         return (rawUTIs as NSArray as? [String] ?? []).map { UTI($0) }
     }
 
-    public static func UTIsFromFilenameExtension(filenameExtension: String, conformingToUTI: UTI? = nil) -> [UTI] {
+    public static func UTIsFromFilenameExtension(_ filenameExtension: String, conformingToUTI: UTI? = nil) -> [UTI] {
         return UTIsForTagClass(kUTTagClassFilenameExtension as String, tag: filenameExtension, conformingToUTI: conformingToUTI)
     }
 
-    public static func UTIsFromMIMEType(MIMEType: String, conformingToUTI: UTI? = nil) -> [UTI] {
+    public static func UTIsFromMIMEType(_ MIMEType: String, conformingToUTI: UTI? = nil) -> [UTI] {
         return UTIsForTagClass(kUTTagClassMIMEType as String, tag: MIMEType, conformingToUTI: conformingToUTI)
     }
 
@@ -90,13 +90,13 @@ public struct UTI: CustomStringConvertible, CustomDebugStringConvertible, Equata
 
     // MARK: - Tags
 
-    private func tagWithClass(tagClass: String) -> String? {
+    private func tagWithClass(_ tagClass: String) -> String? {
         return UTTypeCopyPreferredTagWithClass(UTIString, tagClass)?.takeRetainedValue() as String?
     }
 
-    @available(OSX, introduced=10.10)
-    @available(iOS, introduced=8.0)
-    private func tagsWithClass(tagClass: String) -> [String] {
+    @available(OSX, introduced:10.10)
+    @available(iOS, introduced:8.0)
+    private func tagsWithClass(_ tagClass: String) -> [String] {
         guard let tags = UTTypeCopyAllTagsWithClass(UTIString, tagClass)?.takeRetainedValue() else { return [] }
         return tags as NSArray as? [String] ?? []
     }
@@ -105,8 +105,8 @@ public struct UTI: CustomStringConvertible, CustomDebugStringConvertible, Equata
         return tagWithClass(kUTTagClassFilenameExtension as String)
     }
 
-    @available(OSX, introduced=10.10)
-    @available(iOS, introduced=8.0)
+    @available(OSX, introduced:10.10)
+    @available(iOS, introduced:8.0)
     public var filenameExtensions: [String] {
         return tagsWithClass(kUTTagClassFilenameExtension as String)
     }
@@ -115,8 +115,8 @@ public struct UTI: CustomStringConvertible, CustomDebugStringConvertible, Equata
         return tagWithClass(kUTTagClassMIMEType as String)
     }
 
-    @available(OSX, introduced=10.10)
-    @available(iOS, introduced=8.0)
+    @available(OSX, introduced:10.10)
+    @available(iOS, introduced:8.0)
     public var MIMETypes: [String] {
         return tagsWithClass(kUTTagClassMIMEType as String)
     }
@@ -126,7 +126,7 @@ public struct UTI: CustomStringConvertible, CustomDebugStringConvertible, Equata
         return tagWithClass(kUTTagClassNSPboardType as String)
     }
 
-    @available(OSX, introduced=10.10)
+    @available(OSX, introduced:10.10)
     public var pasteBoardTypes: [String] {
         return tagsWithClass(kUTTagClassNSPboardType as String)
     }
@@ -135,7 +135,7 @@ public struct UTI: CustomStringConvertible, CustomDebugStringConvertible, Equata
         return tagWithClass(kUTTagClassOSType as String)
     }
 
-    @available(OSX, introduced=10.10)
+    @available(OSX, introduced:10.10)
     public var OSTypes: [String] {
         return tagsWithClass(kUTTagClassOSType as String)
     }
@@ -143,14 +143,14 @@ public struct UTI: CustomStringConvertible, CustomDebugStringConvertible, Equata
 
     // MARK: - Status
 
-    @available(OSX, introduced=10.10)
-    @available(iOS, introduced=8.0)
+    @available(OSX, introduced:10.10)
+    @available(iOS, introduced:8.0)
     public var isDeclared: Bool {
         return UTTypeIsDeclared(UTIString)
     }
 
-    @available(OSX, introduced=10.10)
-    @available(iOS, introduced=8.0)
+    @available(OSX, introduced:10.10)
+    @available(iOS, introduced:8.0)
     public var isDynamic: Bool {
         return UTTypeIsDynamic(UTIString)
     }
@@ -191,9 +191,9 @@ public struct UTI: CustomStringConvertible, CustomDebugStringConvertible, Equata
             return raw[kUTTypeIconFileKey] as? String
         }
 
-        public var referenceURL: NSURL? {
+        public var referenceURL: URL? {
             if let reference = raw[kUTTypeReferenceURLKey] as? String {
-                return NSURL(string: reference)
+                return URL(string: reference)
             }
             return nil
         }
@@ -220,17 +220,17 @@ public struct UTI: CustomStringConvertible, CustomDebugStringConvertible, Equata
         return Declaration(declaration: UTTypeCopyDeclaration(self.UTIString)?.takeRetainedValue() as [NSObject: AnyObject]? ?? [:])
     }
 
-    public var declaringBundle: NSBundle? {
-        if let URL = UTTypeCopyDeclaringBundleURL(UTIString)?.takeRetainedValue() {
-            return NSBundle(URL: URL)
+    public var declaringBundle: Bundle? {
+        if let url = UTTypeCopyDeclaringBundleURL(UTIString)?.takeRetainedValue() {
+            return Bundle(url: url as URL)
         }
         return nil
     }
 
-    public var iconFileURL: NSURL? {
+    public var iconFileURL: URL? {
         if let iconFile = declaration.iconFile {
-            return self.declaringBundle?.URLForResource(iconFile, withExtension: nil) ??
-                   self.declaringBundle?.URLForResource(iconFile, withExtension: "icns")
+            return self.declaringBundle?.urlForResource(iconFile, withExtension: nil) ??
+                   self.declaringBundle?.urlForResource(iconFile, withExtension: "icns")
         }
         return nil
     }

--- a/UTIKitTests/UTITests.swift
+++ b/UTIKitTests/UTITests.swift
@@ -90,11 +90,11 @@ class UTITests: XCTestCase {
         let pages = UTI(filenameExtension: "pages")!
         XCTAssertTrue(pages.declaration.exportedTypeDeclarations.isEmpty)
         XCTAssertTrue(pages.declaration.importedTypeDeclarations.isEmpty)
-        XCTAssertEqual(pages.declaration.identifier!, "com.apple.iWork.Pages.pages")
+        XCTAssertEqual(pages.declaration.identifier?.lowercased(), "com.apple.iwork.pages.pages")
         XCTAssertNotNil(pages.declaration.tagSpecification)
         XCTAssertEqual(pages.declaration.conformsTo, [ UTI(kUTTypePackage as String), UTI(kUTTypeCompositeContent as String) ])
         XCTAssertNil(pages.declaration.iconFile)
-        XCTAssertEqual(pages.declaration.referenceURL!, NSURL(string: "http://www.apple.com/iwork/pages/")!)
+        XCTAssertEqual(pages.declaration.referenceURL!, URL(string: "http://www.apple.com/iwork/pages/")!)
         XCTAssertNil(pages.declaration.version)
     }
 


### PR DESCRIPTION
I'm submitting this request to master, but I believe that there should be a swift-3 branch instead. What I would propose as the timeline would be:
1. Maintain 2.3 and 3.0 branches until Xcode 8 GM is released.
2. Keep the 2.3 branch long term for legacy support.
3. Merge 3.0 into master.
4. When the next version of Swift is released, create a legacy swift-3.0 branch off of master.

This way, user's of the framework can target a specific branch if they need legacy support, or master if they want the most current version.

Thoughts?
