### PR TITLE
Update to swift version 5.0 and Xcode 11

### DIFF
--- a/UTIKit.podspec
+++ b/UTIKit.podspec
@@ -1,7 +1,7 @@
 Pod::Spec.new do |s|
 
   s.name         = "UTIKit"
-  s.version      = "2.0.2"
+  s.version      = "2.0.3"
   s.summary      = "UTIKit is an UTI (Uniform Type Identifier) wrapper for Swift."
 
   s.description  = <<-DESC
@@ -24,7 +24,7 @@ Pod::Spec.new do |s|
   s.author             = { "Hiroki Kato" => "mail@cockscomb.info" }
   s.social_media_url   = "http://twitter.com/cockscomb"
 
-  s.swift_version = '4.0'
+  s.swift_version = '5.0'
 
   s.ios.deployment_target = "8.0"
   s.osx.deployment_target = "10.10"

--- a/UTIKit.xcodeproj/project.pbxproj
+++ b/UTIKit.xcodeproj/project.pbxproj
@@ -211,21 +211,21 @@
 					};
 					09FD213A1A962FC00071BF6B = {
 						CreatedOnToolsVersion = 6.1.1;
-						LastSwiftMigration = 0920;
+						LastSwiftMigration = 1100;
 					};
 					09FD21451A962FC00071BF6B = {
 						CreatedOnToolsVersion = 6.1.1;
-						LastSwiftMigration = 0920;
+						LastSwiftMigration = 1100;
 					};
 				};
 			};
 			buildConfigurationList = 09FD21351A962FC00071BF6B /* Build configuration list for PBXProject "UTIKit" */;
 			compatibilityVersion = "Xcode 10.0";
-			developmentRegion = English;
+			developmentRegion = en;
 			hasScannedForEncodings = 0;
 			knownRegions = (
-				English,
 				en,
+				Base,
 			);
 			mainGroup = 09FD21311A962FC00071BF6B;
 			productRefGroup = 09FD213C1A962FC00071BF6B /* Products */;
@@ -486,9 +486,11 @@
 					"@executable_path/Frameworks",
 					"@loader_path/Frameworks",
 				);
+				MARKETING_VERSION = 2.0.3;
 				PRODUCT_BUNDLE_IDENTIFIER = "info.cockscomb.$(PRODUCT_NAME:rfc1034identifier)";
 				PRODUCT_NAME = UTIKit;
 				SKIP_INSTALL = YES;
+				SWIFT_VERSION = 5.0;
 			};
 			name = Debug;
 		};
@@ -510,9 +512,11 @@
 					"@executable_path/Frameworks",
 					"@loader_path/Frameworks",
 				);
+				MARKETING_VERSION = 2.0.3;
 				PRODUCT_BUNDLE_IDENTIFIER = "info.cockscomb.$(PRODUCT_NAME:rfc1034identifier)";
 				PRODUCT_NAME = UTIKit;
 				SKIP_INSTALL = YES;
+				SWIFT_VERSION = 5.0;
 			};
 			name = Release;
 		};
@@ -535,6 +539,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = "info.cockscomb.$(PRODUCT_NAME:rfc1034identifier)";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
+				SWIFT_VERSION = 5.0;
 			};
 			name = Debug;
 		};
@@ -553,6 +558,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = "info.cockscomb.$(PRODUCT_NAME:rfc1034identifier)";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
+				SWIFT_VERSION = 5.0;
 			};
 			name = Release;
 		};

--- a/UTIKit/Info.plist
+++ b/UTIKit/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>FMWK</string>
 	<key>CFBundleShortVersionString</key>
-	<string>2.0.2</string>
+	<string>$(MARKETING_VERSION)</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>


### PR DESCRIPTION
Hi @cockscomb ,
I basically open the project in Xcode 11 and remove basics warning for compatibility with swift 5.0
I also already update pod version to 2.0.3.
Thanks in advance for the new release.